### PR TITLE
WebCamera integration

### DIFF
--- a/public/3D.js
+++ b/public/3D.js
@@ -9,19 +9,22 @@ var material;
 var object;
 var myID;
 var requestID = undefined;
-
 var userCount = 0;
-const distance = 15;
+var listener;
+var allObjects = []; // Stores all 3D objects so that they can be removed later
 
+let wallLeft;
+let wallRight;
+let wallFront;
+
+const distance = 15;
 const maxX = 100;
 const maxY = 100; // This is probably not needed
 const maxZ = 100;
 const speed = 3;
+const wallHeight = 100;
 
-var listener;
-
-var allObjects = [];
-
+// Initialises the 3D environment, including adding our own avatar
 function init3D() {
 	scene = new THREE.Scene();
 	scene.background = new THREE.Color( 0xf0f0f0 );
@@ -87,51 +90,51 @@ function init3D() {
 	update();
 }
 
-//Create the texture to display video on wall
-for (var x in remoteStreamList) {
-	var video = remoteStreamList[x];
-	var texture = new THREE.VideoTexture(video);
-	texture.minFilter = THREE.LinearFilter;
-	texture.magFilter = THREE.LinearFilter;
-	texture.format = THREE.RGBFormat;
-}
-
 function addWalls() {
-	if (remoteStreamList.length > 0) {
-		for (var x in remoteStreamList) {
-			var video = document.getElementById(remoteStreamList[x]);
-			var texture = new THREE.VideoTexture(video);
+	let texture = 0;
+
+	if (wallLeft && wallRight && wallFront) {
+		scene.remove(wallLeft);
+		scene.remove(wallRight);
+		scene.remove(wallFront);
+	}
+
+	if (screenShare.srcObject) {
+			texture = new THREE.VideoTexture(screenShare);
 			texture.minFilter = THREE.LinearFilter;
 			texture.magFilter = THREE.LinearFilter;
 			texture.format = THREE.RGBFormat;
-		}
-	}	else {
-		var texture = 0;
 	}
 
-	let wallHeight = 100;
-
-	var wallLeft = new THREE.Mesh(
+	wallLeft = new THREE.Mesh(
 		new THREE.PlaneGeometry(maxY * 2, wallHeight, 1, 1),
-		new THREE.MeshBasicMaterial({color: 0xff0000, side: THREE.DoubleSide})
+		new THREE.MeshBasicMaterial( { color: 0xff0000, side: THREE.DoubleSide } )
 	);
 
-	wallLeft.rotation.y += Math.PI / 2; //can rotate the floor/plane
+	wallLeft.rotation.y += Math.PI / 2;
 	wallLeft.position.x = -maxX;
 	wallLeft.position.y += wallHeight / 2;
 
-	var wallRight = new THREE.Mesh(
+	wallRight = new THREE.Mesh(
 		new THREE.PlaneGeometry(maxY * 2, wallHeight, 1, 1),
-		new THREE.MeshBasicMaterial({color: 0xff0000, side: THREE.DoubleSide})
+		new THREE.MeshBasicMaterial( { color: 0xff0000, side: THREE.DoubleSide } )
 	);
 
-	wallRight.rotation.y += Math.PI / 2; //can rotate the floor/plane
+	wallRight.rotation.y += Math.PI / 2;
 	wallRight.position.x = maxX;
 	wallRight.position.y += wallHeight / 2;
 
-	var wallFront = new THREE.Mesh(
-		new THREE.PlaneBufferGeometry(maxX * 2, wallHeight, 1, 1),
-		new THREE.MeshBasicMaterial({side: THREE.DoubleSide, map: texture}));
+	if (!texture) { // If there is no video assign a colour to the front wall
+		wallFront = new THREE.Mesh(
+			new THREE.PlaneBufferGeometry(maxX * 2, wallHeight, 1, 1),
+			new THREE.MeshBasicMaterial( { color: 0xff0000, side: THREE.DoubleSide } )
+		);
+	} else { // If there is a video place the video texture on the wall
+		wallFront = new THREE.Mesh(
+			new THREE.PlaneBufferGeometry(maxX * 2, wallHeight, 1, 1),
+			new THREE.MeshBasicMaterial( { side: THREE.DoubleSide, map: texture } )
+		);
+	}
 
 	wallFront.position.z = -maxZ;
 	wallFront.position.y += wallHeight / 2;
@@ -157,6 +160,7 @@ function removeUser(id) {
 	return UserMap.delete(id);
 }
 
+// Returns the user object corresponding to the given user ID
 function findUser(id) {
 	return UserMap.get(id);
 }
@@ -346,7 +350,7 @@ function nameChange(userer, newname) {
 function leave3D() {
 
 	for (let i in allObjects) {
-		scene.remove(allObjects[i]);
+		if (allObjects[i]) scene.remove(allObjects[i]);
 	}
 
 	document.removeEventListener("keydown", onDocumentKeyDown);

--- a/public/3D.js
+++ b/public/3D.js
@@ -40,7 +40,7 @@ function init3D() {
 
 	// RENDERER
 	renderer = new THREE.WebGLRenderer();
-	renderer.setSize(window.innerWidth - 5, window.innerHeight - 25);
+	renderer.setSize(window.innerWidth - 5, window.innerHeight - 30);
 	renderer.domElement.id = "scene"; // Adds an ID to the canvas element
 	document.getElementById("3D").appendChild( renderer.domElement);
 

--- a/public/3D.js
+++ b/public/3D.js
@@ -40,7 +40,7 @@ function init3D() {
 
 	// RENDERER
 	renderer = new THREE.WebGLRenderer();
-	renderer.setSize(window.innerWidth - 5, window.innerHeight - 30);
+	renderer.setSize(window.innerWidth, window.innerHeight - 30);
 	renderer.domElement.id = "scene"; // Adds an ID to the canvas element
 	document.getElementById("3D").appendChild( renderer.domElement);
 

--- a/public/3D.js
+++ b/public/3D.js
@@ -20,6 +20,8 @@ const speed = 3;
 
 var listener;
 
+var allObjects = [];
+
 function init3D() {
 	scene = new THREE.Scene();
 	scene.background = new THREE.Color( 0xf0f0f0 );
@@ -48,6 +50,7 @@ function init3D() {
 	);
 	floor.rotation.x += Math.PI / 2; //can rotate the floor/plane
 	scene.add( floor );
+	allObjects.push(floor);
 
 	addWalls();
 
@@ -57,6 +60,7 @@ function init3D() {
 	geometry = new THREE.BoxGeometry(10, 20, 10);
 	material = new THREE.MeshBasicMaterial( {color: 0x669966, wireframe: false});
 	object = new THREE.Mesh(geometry, material);
+	allObjects.push(object);
 
 	// ADD GLTFLOADER HERE
 
@@ -135,9 +139,11 @@ function addWalls() {
 	scene.add( wallLeft );
 	scene.add( wallRight );
 	scene.add( wallFront );
+	allObjects.push( wallLeft );
+	allObjects.push( wallRight );
+	allObjects.push( wallFront );
 
 	renderer.render(scene, camera);
-
 }
 
 //function to add a user to the UsersMap
@@ -198,6 +204,7 @@ var makeNewObject = function(xPosition, yPosition, zPosition) {
 	object.position.y = yPosition;
 	object.position.z = zPosition;
 	scene.add(object);
+	allObjects.push(object);
 	return object;
 };
 
@@ -337,6 +344,11 @@ function nameChange(userer, newname) {
 }
 
 function leave3D() {
+
+	for (let i in allObjects) {
+		scene.remove(allObjects[i]);
+	}
+
 	document.removeEventListener("keydown", onDocumentKeyDown);
 	document.removeEventListener("keyup", onDocumentKeyUp);
 	if (document.getElementById("scene")) {

--- a/public/client.js
+++ b/public/client.js
@@ -419,7 +419,6 @@ function stopShareCamera() {
 
   tracks.forEach(track => track.stop()); // Stop all relevant media tracks
   cameraLi.children[0].srcObject = null;
-  screenShare.hidden = true;
 
   cameraLi.innerHTML = '';
 
@@ -603,6 +602,8 @@ function leave() {
   users.style.display = "none";
   connectionList.innerHTML = '';
   openButton.hidden = true;
+  videoElement.innerHTML = '<ul></ul>';
+  cameraButton.hidden = true;
   for (let id in connections) {
     if (connections[id].stream)
       connections[id].stream.getTracks().forEach(track => track.stop()); // Stop all remote media tracks

--- a/public/client.js
+++ b/public/client.js
@@ -590,6 +590,7 @@ function leave() {
     window.URL.revokeObjectURL(textFile); // Avoid memory leaks
   }
 
+  stopShareScreen();
   stopShareCamera();
 
   files.hidden = true;
@@ -619,10 +620,7 @@ function leave() {
   localStream.getTracks().forEach(track => track.stop()); // Stop all local media tracks
   localStream = null;
 
-  stopShareScreen();
-
   leave3D(); // Closes the 3D environment
-
   stop();
 
   if (room) {

--- a/public/client.js
+++ b/public/client.js
@@ -397,6 +397,10 @@ function stopShareScreen() {
   shareButton.onclick = function () { shareScreen() };
   shareButton.value = "Share Screen";
 
+  if (!screenShare.srcObject) {
+    return;
+  }
+
   let tracks = screenShare.srcObject.getTracks();
 
   tracks.forEach(track => track.stop());

--- a/public/client.js
+++ b/public/client.js
@@ -41,7 +41,8 @@ chatSend.addEventListener("keyup", function(event) {
     }
   });
 
-var localStream; // This is our local audio stream
+var localAudioStream; // This is our local audio stream
+var localVideoTrack; // This is our local video stream
 var room; // This is the name of our conference room
 var socket; // This is the SocketIO connection to the signalling server
 var ourID; // This is our unique ID
@@ -81,7 +82,10 @@ const screenShareConstraints = {
 
 const cameraConstraints = {
   audio: false,
-  video: true
+  video: {
+    width: 250,
+    height: 200
+  }
 };
 
 // Adds a username to the list of connections on the HTML page
@@ -353,7 +357,8 @@ async function shareCamera() {
   let cameraCapture;
 
   try {
-    cameraCapture = await navigator.mediaDevices.getUserMedia({audio: false, video: true});
+    cameraCapture = await navigator.mediaDevices.getUserMedia(cameraConstraints);
+    localVideoTrack = cameraCapture.getVideoTracks()[0];
   } catch(e) {
     if (e.name === "NotAllowedError") {
       alert('Unfortunately, access to the microphone is necessary in order to use the program. ' +

--- a/public/client.js
+++ b/public/client.js
@@ -423,6 +423,10 @@ function stopShareCamera() {
   cameraLi.innerHTML = '';
 
   videoElement.children[0].removeChild(cameraLi);
+
+  if (videoElement.children[0].children.length == 0) {
+    renderer.setSize(window.innerWidth, window.innerHeight - 30);
+  }
 }
 
 // Shares our screen with the other users, if noone is doing so already

--- a/public/client.js
+++ b/public/client.js
@@ -382,6 +382,8 @@ async function shareCamera() {
   videoElement.children[0].appendChild(cameraStreamLi);
   videoElement.hidden = false;
 
+  renderer.setSize(window.innerWidth - 320, window.innerHeight - 30);
+
   cameraButton.value = "Stop Sharing Camera";
   cameraButton.onclick = function () { stopShareCamera(cameraCapture.id) };
 
@@ -532,6 +534,7 @@ function openChat() {
 
   openButton.onclick = function() { open3D() };
   openButton.value = "Open 3D";
+  document.body.style.backgroundColor = "white";
 }
 
 // Open the 3D environment and hide the chat
@@ -545,6 +548,8 @@ function open3D() {
 
   openButton.onclick = function() { openChat() };
   openButton.value = "Open Chat";
+
+  document.body.style.backgroundColor = "grey";
 }
 
 // Make 'c'-keypress swap between chat and 3D-space

--- a/public/connect.js
+++ b/public/connect.js
@@ -64,6 +64,7 @@ function init() {
     console.log("User " + connections[id].name + " left");
     removeConnectionHTMLList(id);
     userLeft(id) // Removes the user from the 3D environment
+    if (connections[id].stream) document.getElementById(connections[id].stream.id).outerHTML = '';
     if (connections[id].connection) connections[id].connection.close();
     if (connections[id].dataChannel) connections[id].dataChannel.close();
     delete connections[id];
@@ -307,7 +308,7 @@ function createPeerConnection(id) {
 
       if (event.streams[0]) {
         event.streams[0].onremovetrack = function (event) {
-          console.log(connections[id].name + ' removed a track.')
+          console.log(connections[id].name + ' removed a track from their stream.')
           if (event.track.kind == "video") {
             let cameraLi = document.getElementById(connections[id].stream.id);
 

--- a/public/connect.js
+++ b/public/connect.js
@@ -318,6 +318,10 @@ function createPeerConnection(id) {
             cameraLi.innerHTML = '';
 
             videoElement.children[0].removeChild(cameraLi);
+
+            if (videoElement.children[0].children.length == 0) {
+              renderer.setSize(window.innerWidth, window.innerHeight - 30);
+            }
           }
         }
       }

--- a/public/connect.js
+++ b/public/connect.js
@@ -270,24 +270,40 @@ function createPeerConnection(id) {
       }
 
       if (event.track.kind == "video") {
-        if (sharing && id == shareUser) {
-          screenShare.srcObject = newStream; // Screen capture video
+        if (sharing && id == shareUser) { // Screen capture video
+          screenShare.srcObject = newStream;
 
           if (document.getElementById(newStream.id)){
             return
           }
-
+          screenShare.srcObject = null;
+          screenShare.autoplay = true;
+          screenShare.srcObject = newStream;
+          addWalls();
+        } else { // Web camera video
           let remoteStream = document.createElement("video");
+          let remoteStreamLi = document.createElement("li");
           remoteStream.id = newStream.id;
-          remoteStreamList.push(remoteStream.id);
           remoteStream.autoplay = true;
           remoteStream.srcObject = newStream;
-          document.getElementById("video").appendChild(remoteStream);
-          addWalls();
-        } else {
-          // Web camera video
+          remoteStreamLi.appendChild(remoteStream);
+          videoElement.children[0].appendChild(remoteStreamLi);
+          videoElement.hidden = false;
         }
       }
+
+      newStream.onremovetrack = function (event) {
+        if (event.track.kind == "video") {
+          let cameraLi = document.getElementById(event.track.id);
+
+          cameraLi.children[0].srcObject = null;
+          screenShare.hidden = true;
+
+          cameraLi.innerHTML = '';
+
+          videoElement.children[0].removeChild(cameraLi);
+        }
+      };
     };
     pc.onremovestream = function (event) {
       console.log("Lost a stream from " + connections[id].name);

--- a/public/connect.js
+++ b/public/connect.js
@@ -1,11 +1,11 @@
 function init() {
 
-  if (username.value === '') {
+  if (username.value === '') { // No username given
     alert('Please enter a username');
     return;
   }
 
-  if (roomName.value === '') {
+  if (roomName.value === '') { // No room name given
     alert('Please enter a room name');
     return;
   }
@@ -50,7 +50,7 @@ function init() {
     ourID = connectionInfo.id;
 
     init3D(); // Renders the 3D environment
-    initSwapView();
+    initSwapView(); // Lets the user quickly switch between chat mode and 3D mode
   });
 
   // A user moved in the 3D space
@@ -91,7 +91,7 @@ function init() {
     newUserJoined(id, name); // Add new user to 3D environment
   });
 
-  // We have received a PeerConnection offer
+  // We have received an updated PeerConnection offer
   socket.on('newOffer', function(message) {
     let id = message.id;
     let offerDescription = message.offer;
@@ -126,7 +126,7 @@ function init() {
     appendConnectionHTMLList(id);
   });
 
-  // We have received a PeerConnection offer
+  // We have received an answer to our updated PeerConnection offer
   socket.on('newAnswer', function(message) {
 
     let id = message.id;

--- a/public/connect.js
+++ b/public/connect.js
@@ -292,6 +292,7 @@ function createPeerConnection(id) {
           remoteStreamLi.appendChild(remoteStream);
           videoElement.children[0].appendChild(remoteStreamLi);
           videoElement.hidden = false;
+          renderer.setSize(window.innerWidth - 320, window.innerHeight - 30);
         }
       }
 

--- a/public/connect.js
+++ b/public/connect.js
@@ -183,6 +183,9 @@ function sendOffer(id) {
   createDataChannel(id);
 
   connections[id].connection.addStream(localStream);
+  if (localVideoTrack) {
+    connections[id].connection.addTrack(localVideoTrack);
+  }
 
   connections[id].connection.createOffer().then(function(description) {
     connections[id].connection.setLocalDescription(description);

--- a/public/connect.js
+++ b/public/connect.js
@@ -272,30 +272,28 @@ function createPeerConnection(id) {
       let newStream = new MediaStream([event.track]) // Create a new stream containing the received track
 
       if (event.track.kind == "audio") {
-        userGotMedia(id, newStream); // Adds track to 3D environment
+        userGotMedia(id, newStream); // Adds audio track to 3D environment
       }
 
       if (event.track.kind == "video") {
         if (sharing && id == shareUser) { // Screen capture video
           screenShare.srcObject = newStream;
 
-          if (document.getElementById(newStream.id)){
-            return
-          }
+          if (document.getElementById(newStream.id)) return; // Ignore if there already is screen sharing
+
           screenShare.srcObject = null;
           screenShare.autoplay = true;
           screenShare.srcObject = newStream;
-          addWalls();
+          addWalls(); // Add the video track to the 3D environment
+          
         } else { // Web camera video
-          if (!event.streams[0]) {
-            return;
-          }
+
+          if (!event.streams[0]) return; // Web camera videos should always be in a stream
 
           connections[id].stream = event.streams[0];
 
           let remoteStream = document.createElement("video");
           let remoteStreamLi = document.createElement("li");
-
           remoteStreamLi.id = event.streams[0].id;
           remoteStream.autoplay = true;
           remoteStream.srcObject = event.streams[0];
@@ -307,21 +305,18 @@ function createPeerConnection(id) {
       }
 
       if (event.streams[0]) {
-        event.streams[0].onremovetrack = function (event) {
+        event.streams[0].onremovetrack = function (event) { // A track has been removed
           console.log(connections[id].name + ' removed a track from their stream.')
           if (event.track.kind == "video") {
-            let cameraLi = document.getElementById(connections[id].stream.id);
 
+            let cameraLi = document.getElementById(connections[id].stream.id);
             cameraLi.children[0].srcObject = null;
             screenShare.hidden = true;
-
             cameraLi.innerHTML = '';
-
             videoElement.children[0].removeChild(cameraLi);
 
-            if (videoElement.children[0].children.length == 0) {
+            if (videoElement.children[0].children.length == 0)
               renderer.setSize(window.innerWidth, window.innerHeight - 30);
-            }
           }
         }
       }

--- a/public/index.css
+++ b/public/index.css
@@ -88,3 +88,24 @@ files {
   margin-left: 50px;
   background-color: #ff6666;
 }
+
+videos ul {
+  list-style-type: none;
+  padding-left: 0px;
+  display: inline-block;
+  vertical-align: super;
+  position: absolute;
+  right: 0px;
+  position: absolute;
+  top: 0%;
+}
+
+videos ul li {
+  list-style-type: none;
+  padding-bottom: 0px;
+  padding-top: 0px;
+}
+
+buttons {
+  display: inline-block;
+}

--- a/public/index.css
+++ b/public/index.css
@@ -109,3 +109,9 @@ videos ul li {
 buttons {
   display: inline-block;
 }
+
+canvas {
+  position: absolute;
+  left: 0%;
+  bottom: 0%;
+}

--- a/public/index.css
+++ b/public/index.css
@@ -89,6 +89,13 @@ files {
   background-color: #ff6666;
 }
 
+videos {
+  position: absolute;
+  top: 0%;
+  position: absolute;
+  right: 0%;
+}
+
 videos ul {
   list-style-type: none;
   padding-left: 0px;

--- a/public/index.html
+++ b/public/index.html
@@ -62,17 +62,20 @@
 				<br/>
 				<a id="download" target="_blank" hidden>Download file</a>
 			</received>
-
-			<video controls muted id="localVideo" autoplay playsinline hidden></video>
-			<div id="video" hidden>
-				<!-- Received video streams go here -->
-			</div>
-
 		</div>
 
-		<input type="button" id="open" onclick="open3D()" value="Open Chat" hidden></input>
+		<video controls muted id="localVideo" autoplay playsinline hidden></video>
+		<videos id="remoteVideo" hidden>
+			<ul>
+				<!-- Received video streams go here -->
+			</ul>
+		</videos>
 
-		<input type="button" id="shareButton" onclick="shareScreen()" value="Share Screen" hidden></input>
+		<buttons>
+			<input type="button" id="open" onclick="open3D()" value="Open Chat" hidden></input>
+			<input type="button" id="shareButton" onclick="shareScreen()" value="Share Screen" hidden></input>
+			<input type="button" id="cameraButton" onclick="shareCamera()" value="Add video" hidden></input>
+		</buttons>
 
 		<div id="3D">
 			<notification id="notification"></notification>

--- a/public/index.html
+++ b/public/index.html
@@ -47,12 +47,12 @@
 			<br/>
 
 			<files id="files" hidden>
-				Share Files:
+				Your Files:
 				<br/>
 				<br/>
 				<uploadFile>
 	      	<input type="file" id="sendFile" multiple>
-	      	<button onclick="advertiseFile()" id="uploadButton">Upload File</button>
+	      	<button onclick="advertiseFile()" id="uploadButton">Share File</button>
 				</uploadFile>
 				<p id="remoteFiles" hidden> Remote Files: </p>
 	    </files>
@@ -65,7 +65,7 @@
 
 			<video controls muted id="localVideo" autoplay playsinline hidden></video>
 			<div id="video" hidden>
-				<!-- Videos in the 3D environment go here -->
+				<!-- Received video streams go here -->
 			</div>
 
 		</div>
@@ -79,8 +79,7 @@
 			<!-- This is where the 3D canvas goes -->
 		</div>
 
-
-		<video id="screenTest" style="border: 1px solid #999; width: 98%; max-width: 860px;" hidden autoplay></video>
+		<video id="screenShare" style="border: 1px solid #999; width: 98%; max-width: 860px;" hidden autoplay></video>
 
 	  <script src="socket.io.js"></script>
 	  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>

--- a/signal.js
+++ b/signal.js
@@ -27,12 +27,13 @@ io.sockets.on('connection', function(socket) {
   });
 
   socket.on('disconnect', function() {
-    if (users[socket.id] !== undefined)
+    if (users[socket.id])
       io.sockets.in(users[socket.id].room).emit('left', socket.id);
   });
 
   socket.on('left', function() {
-    io.sockets.in(users[socket.id].room).emit('left', socket.id);
+    if (users[socket.id])
+      io.sockets.in(users[socket.id].room).emit('left', socket.id);
   })
 
   socket.on('newOffer', function(data) {


### PR DESCRIPTION
In this pull request webcamera video is supported. This means that users can choose to enable their cameras, which will display them to the other participants. This stream will be displayed in a vertical list on the right side of the screen in both chat mode and 3D mode. The 3D canvas is resized when a new camera stream is added and when there are no more streams. 

Screen sharing is now fully integrated into the 3D environment. The shared screen is displayed in the front wall in 3D. When a screen is not being shared then this wall has the same texture as the other walls. 

As with most of these pull requests, there are also minor HTML/CSS improvements. It is particularly worth noting that each seperate "page" (3D and chat) are now in seperate overarching sections, which makes switching between them easier. 

In general there have been several attempts to make the code cleaner. Some more complexity had to be added though in order to implement adding video tracks to an existing stream and dealing with them when a track is removed. The webcamera and microphone tracks both belong to the same PeerConnections stream, whilst the screen sharing video is an isolated track. 

In order to minimise memory leaks, all streams are now closed when a user leaves, and in 3D.js the 3D objects are removed when the 3D scene is closed. 