### PR TITLE
Error fixing

### DIFF
--- a/public/3D.js
+++ b/public/3D.js
@@ -525,6 +525,10 @@ function onDocumentKeyUp(event) {
 	}
 }
 
+/**
+ * Called when the width or height of the webpage is changed. The 3D scene is
+ * reshaped as a result.
+ */
 function onWindowResize() {
 	resizeCanvas(-1);
 }
@@ -541,7 +545,6 @@ function resizeCanvas(newWidth) {
 		videoWidth = newWidth;
 	renderer.setSize( window.innerWidth - videoWidth, window.innerHeight - 30 );
 }
-
 
 //function to update frame
 function update() {

--- a/public/3D.js
+++ b/public/3D.js
@@ -99,7 +99,7 @@ function init3D() {
  * Places the given video stream in the 3D environment. If it is null, then we
  * only remove the existing one.
  */
-function updateShareScreen3D(screenObject) {
+function updateShareScreen3D(screenObject, details) {
 	scene.remove(tv);
 	if (screenObject) { // If someone is sharing their screen, display it
 		texture = new THREE.VideoTexture(screenObject);
@@ -107,9 +107,13 @@ function updateShareScreen3D(screenObject) {
 		texture.magFilter = THREE.LinearFilter;
 		texture.format = THREE.RGBFormat;
 
-		let height = screenObject.srcObject.getVideoTracks()[0].getSettings().height;
-		let width = screenObject.srcObject.getVideoTracks()[0].getSettings().width;
+		let height = details.height;
+		let width = details.width;
 		let ratio = width / height;
+
+		console.log(screenObject.srcObject.getVideoTracks()[0].getSettings())
+
+		console.log("h:", height, "w:", width);
 
 		// This block of code makes the video fit the screen whilst maintaining the original aspect ratio
 		if (height > wallHeight) {
@@ -131,6 +135,8 @@ function updateShareScreen3D(screenObject) {
 				height = height2;
 			}
 		}
+
+		console.log("h:", height, "w:", width, "h2:", height2, "w2:", width2);
 
 		tv = new THREE.Mesh(
 			new THREE.PlaneBufferGeometry(width, height, 1, 1),

--- a/public/3D.js
+++ b/public/3D.js
@@ -526,9 +526,6 @@ function onDocumentKeyUp(event) {
 }
 
 function onWindowResize() {
-
-	camera.aspect = window.innerWidth / window.innerHeight;
-	camera.updateProjectionMatrix();
 	resizeCanvas(-1);
 }
 
@@ -538,6 +535,8 @@ function onWindowResize() {
  * If it is -1 then the previously used value of videoWidth will be used.
  */
 function resizeCanvas(newWidth) {
+	camera.aspect = window.innerWidth / window.innerHeight;
+	camera.updateProjectionMatrix();
 	if (newWidth >= 0)
 		videoWidth = newWidth;
 	renderer.setSize( window.innerWidth - videoWidth, window.innerHeight - 30 );

--- a/public/client.js
+++ b/public/client.js
@@ -268,6 +268,12 @@ async function shareScreen(button) {
     return;
   }
 
+  if (sharing.id) { // If someone else starts sharing whilst we select our screen, use theirs
+    let tracks = screenCapture.getTracks();
+    tracks.forEach(track => track.stop());
+    return;
+  }
+
   button.value = "Stop Sharing Screen";
   button.onclick = function () { stopShareScreen(button) };
 
@@ -407,6 +413,10 @@ function dataChannelReceive(id, data) {
   }
 }
 
+/**
+ * Adds the given stream to the 3D environment, passing along the video width
+ * and height as it does so.
+ */
 function updateShareScreen(videoStream) {
   let shareHTML = document.getElementById("screenShare");
   shareHTML.srcObject = videoStream; // Create a new stream containing the received track

--- a/public/client.js
+++ b/public/client.js
@@ -54,8 +54,7 @@ var connections = {}; // The key is the socket id, and the value is:
 
 var localStream = null; // This is our local media stream
 var textFile = null; // This stores any downloaded file
-var sharing = false; // Is someone sharing their screen
-var shareUser = null; // Which user is sharing their screen
+var sharing = {}; // Information about the screen sharing: { id: Number, width: Number, height: Number }
 var screenCapture = null; // The stream containing the video capture of our screen
 var unreadMessages = 0; // The number of messages we have received whilst not in 'chat mode'
 const maxChatLength = 20; // The chat will only hold this many messages at a time
@@ -253,7 +252,7 @@ function stopShareCamera(button) {
  */
 async function shareScreen(button) {
 
-  if (shareUser) return; // Someone else is sharing their screen
+  if (sharing.id) return; // Someone else is sharing their screen
 
   try {
     screenCapture = await navigator.mediaDevices.getDisplayMedia(screenShareConstraints); // Ask for the screen capture
@@ -272,12 +271,12 @@ async function shareScreen(button) {
   button.value = "Stop Sharing Screen";
   button.onclick = function () { stopShareScreen(button) };
 
-  shareUser = ourID; // We are the one sharing our screen
+  sharing.id = ourID; // We are the one sharing our screen
+  sharing.width = screenCapture.getVideoTracks()[0].getSettings().width;
+  sharing.height = screenCapture.getVideoTracks()[0].getSettings().height;
   screenShare.srcObject = screenCapture;
-  sharing = true;
-  updateShareScreen3D(screenShare); // Add the stream to the 3D environment
-
-  addScreenCapture(null);
+  updateShareScreen3D(screenShare, sharing); // Add the stream to the 3D environment
+  addScreenCapture(null); // Notify other users
 }
 
 /**
@@ -285,11 +284,13 @@ async function shareScreen(button) {
  * 'id', or to all connections if 'id' is null.
  */
 function addScreenCapture(id) {
-  if (sharing && shareUser == ourID) { // If we are sharing
+  if (sharing.id && sharing.id == ourID) { // If we are sharing
 
     let shareJSON = JSON.stringify({
       type: "share",
-      sharing: true
+      sharing: true,
+      height: screenCapture.getVideoTracks()[0].getSettings().height,
+      width: screenCapture.getVideoTracks()[0].getSettings().width,
     });
 
     if (id) { // Share it with one user
@@ -311,7 +312,7 @@ function addScreenCapture(id) {
  */
 function stopShareScreen(button) {
 
-  if (!screenShare.srcObject || shareUser !== ourID) {
+  if (!screenShare.srcObject || sharing.id !== ourID) {
     return; // We are not sharing our screen, so we do not need to close anything
   }
 
@@ -322,10 +323,10 @@ function stopShareScreen(button) {
 
   tracks.forEach(track => track.stop()); // Stop the video track
   screenShare.srcObject = null;
-  screenShare.hidden = true;
-  sharing = false; // This indicates that noone is sharing their screen
-  shareUser = null;
-  updateShareScreen3D(null); // Re-add the 3D walls without the video texture
+  sharing.id = null; // This indicates that noone is sharing their screen
+  sharing.width = 0;
+  sharing.height = 0;
+  updateShareScreen3D(null, sharing); // Re-add the 3D walls without the video texture
 
   let shareJSON = JSON.stringify({
     type: "share",
@@ -391,14 +392,26 @@ function dataChannelReceive(id, data) {
   } else if (message.type == "share") { // Someone is sharing their screen
     if (message.sharing) { // If the person has started sharing
       shareButton.hidden = true; // Hide the share screen button
-      shareUser = id; // Save the ID of the sharing user
+      sharing.id = id; // Save the ID of the sharing user
+      sharing.width = message.width;
+      sharing.height = message.height;
     } else { // If they have stopped sharing
-      shareUser = null;
+      sharing.id = null;
+      sharing.width = 0;
+      sharing.height = 0;
+
       shareButton.hidden = false; // Unhide the share screen button
       screenShare.srcObject = null;
-      updateShareScreen3D(null); // Re-add the 3D walls without the video texture
+      updateShareScreen3D(null, sharing); // Re-add the 3D walls without the video texture
     }
-    sharing = message.sharing; // This boolean stores whether or not someone is streaming
+  }
+}
+
+function updateShareScreen(videoStream) {
+  let shareHTML = document.getElementById("screenShare");
+  shareHTML.srcObject = videoStream; // Create a new stream containing the received track
+  if (sharing.id) {
+    updateShareScreen3D(shareHTML, sharing);
   }
 }
 
@@ -669,7 +682,6 @@ function addVideoStream(id, track) {
 function removeVideoStream(id) {
   let cameraLi = document.getElementById(connections[id].stream.id);
   cameraLi.children[0].srcObject = null;
-  screenShare.hidden = true;
   cameraLi.innerHTML = '';
   videoElement.children[0].removeChild(cameraLi);
 
@@ -719,7 +731,7 @@ function initChat() {
   receivedFiles.style.display = "none";
   buttons.hidden = false;
 
-  if ((sharing && shareUser == ourID) || !sharing) {
+  if ((sharing.id && sharing.id == ourID) || !sharing.id) {
     shareButton.hidden = false;
   }
 
@@ -788,12 +800,13 @@ function swapViewOnC(event) {
  */
 function userLeft(id) {
   removeConnectionHTMLList(id);
-  if (id == shareUser) { // If they were sharing their screen then remove it
-    shareUser = null;
-    screenShare.hidden = true;
+  if (id == sharing.id) { // If they were sharing their screen then remove it
+    sharing.id = null;
+    sharing.width = 0;
+    sharing.height = 0;
     screenShare.srcObject = null;
     shareButton.hidden = false;
-    updateShareScreen3D(null);
+    updateShareScreen3D(null, sharing);
   }
   if (connections[id].stream) document.getElementById(connections[id].stream.id).outerHTML = ''; // Remove video
   if (connections[id].dataChannel) connections[id].dataChannel.close(); // Close DataChannel

--- a/public/index.html
+++ b/public/index.html
@@ -80,7 +80,7 @@
 			<!-- This is where the 3D canvas goes -->
 		</div>
 
-		<video id="screenShare" style="border: 1px solid #999; width: 98%; max-width: 860px;" hidden autoplay></video>
+		<video id="screenShare" hidden autoplay />
 
 	  <script src="socket.io.js"></script>
 	  <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>

--- a/public/three.js
+++ b/public/three.js
@@ -18084,8 +18084,6 @@
 
 		var gl = renderer.getContext();
 
-		console.log(parameters)
-
 		var defines = parameters.defines;
 
 		var vertexShader = parameters.vertexShader;

--- a/signal.js
+++ b/signal.js
@@ -2,7 +2,7 @@
 
 var os = require('os');
 
-const maxUsers = 10; // TODO: determine a good value for this
+const maxUsers = 16; // TODO: determine a good value for this
 var rooms = {};
 var users = {};
 
@@ -38,7 +38,7 @@ io.sockets.on('connection', function(socket) {
       io.sockets.in(users[socket.id].room).emit('left', socket.id);
       socket.leave(users[socket.id].room);
     }
-  })
+  });
 
   socket.on('join', function(startInfo) {
 
@@ -55,34 +55,21 @@ io.sockets.on('connection', function(socket) {
       users[socket.id] = { room: room, socket: socket }; // Add the User object to the list of users
 
       socket.join(room); // Add this user to the room
-      socket.emit('created', {room: room, id: socket.id});
+      socket.emit('created', { room: room, id: socket.id } );
 
     } else if (numClients > 0 && numClients < maxUsers) { // Existing room joined
 
       rooms[room].push(socket); // Add the client ID to the list of clients in the room
       users[socket.id] = { room: room, socket: socket }; // Add the User object to the list of users
 
-      socket.emit('joined', {room: room, id: socket.id});
+      socket.emit('joined', { room: room, id: socket.id } ); // Let the user know they joined the room
 
       // Let everyone in the room know that a new user has joined
-      io.sockets.in(room).emit('join', {name: name, id: socket.id});
-
+      io.sockets.in(room).emit('join', { name: name, id: socket.id } );
       socket.join(room); // Add this user to the room
 
     } else { // Someone tried to join a full room
       socket.emit('full', room);
     }
   });
-
-  socket.on('ipaddr', function() {
-    let ifaces = os.networkInterfaces();
-    for (let dev in ifaces) {
-      ifaces[dev].forEach(function(details) {
-        if (details.family === 'IPv4' && details.address !== '127.0.0.1') {
-          socket.emit('ipaddr', details.address);
-        }
-      });
-    }
-  });
-
 });

--- a/signal.js
+++ b/signal.js
@@ -52,7 +52,7 @@ io.sockets.on('connection', function(socket) {
 
       rooms[room] = []; // Create a new entry for this room in the dictionary storing the rooms
       rooms[room].push(socket); // Add the client ID to the list of clients in the room
-      users[socket.id] = new User(room, socket); // Add the User object to the list of users
+      users[socket.id] = { room: room, socket: socket }; // Add the User object to the list of users
 
       socket.join(room); // Add this user to the room
       socket.emit('created', {room: room, id: socket.id});
@@ -60,7 +60,7 @@ io.sockets.on('connection', function(socket) {
     } else if (numClients > 0 && numClients < maxUsers) { // Existing room joined
 
       rooms[room].push(socket); // Add the client ID to the list of clients in the room
-      users[socket.id] = new User(room, socket); // Add the User object to the list of users
+      users[socket.id] = { room: room, socket: socket }; // Add the User object to the list of users
 
       socket.emit('joined', {room: room, id: socket.id});
 
@@ -70,7 +70,7 @@ io.sockets.on('connection', function(socket) {
       socket.join(room); // Add this user to the room
 
     } else { // Someone tried to join a full room
-      io.sockets.in(room).emit('full', room);
+      socket.emit('full', room);
     }
   });
 
@@ -86,27 +86,3 @@ io.sockets.on('connection', function(socket) {
   });
 
 });
-
-
-class User {
-  constructor(room, socket) {
-    this._room = room;
-    this._socket = socket;
-  }
-
-  set room(room) {
-    this._room = room;
-  }
-
-  set socket(socket) {
-    this._socket = socket;
-  }
-
-  get room() {
-    return this._room;
-  }
-
-  get socket() {
-    return this._socket;
-  }
-}


### PR DESCRIPTION
This pull request minimises the number of errors that can occur when using the program. 

A new event listener for when a PeerConnection is closed has been added which deals with unexpected scenearios where a connection may be closed but the signaling server has not yet notified the other users. Similarly, the event listener for when a DataChannel is closed has been expanded so that it stops further errors from occuring.

In order for the aspect ratio of the shared screen to remain constant across connections the program no longer relies on the MediaStreamTrack settings of the video track, but instead explicitly sends this information across the DataChannels before the new stream is added. In the past when someone else shared their screen whilst others were in the process of selecting which screen they wanted to share, the program would enter an inconcistent state with two streams. This is now prevented by re-checking that no new stream has been added, after the promise related to getting the screen capture has returned. 

The code in signal.js has also been cleaned up. Most notably, the User class has been removed. The program now instead just depends on JavaScript objects to store the room and socket information for the users. 